### PR TITLE
We need to check for the authority string 'USER' and not the role

### DIFF
--- a/src/main/java/com/onkibot/backend/config/SecurityConfiguration.java
+++ b/src/main/java/com/onkibot/backend/config/SecurityConfiguration.java
@@ -26,7 +26,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/api/session").permitAll()
                 .antMatchers("/api/signup").permitAll()
-                .antMatchers("/api/**").hasRole("USER")
+                .antMatchers("/api/**").hasAuthority("USER")
                 .and().csrf().disable();
     }
 


### PR DESCRIPTION
See DatabaseUserDetailsService, we never give the user a role, only an authority string.