### PR TITLE
Add user context for all API models

### DIFF
--- a/src/main/java/com/onkibot/backend/api/CategoryController.java
+++ b/src/main/java/com/onkibot/backend/api/CategoryController.java
@@ -29,25 +29,28 @@ public class CategoryController {
   @Autowired private UserRepository userRepository;
 
   @RequestMapping(method = RequestMethod.GET, value = "/{categoryId}")
-  CategoryModel get(@PathVariable int courseId, @PathVariable int categoryId) {
+  CategoryModel get(@PathVariable int courseId, @PathVariable int categoryId, HttpSession session) {
     Category category = this.assertCourseCategory(courseId, categoryId);
-    return new CategoryModel(category);
+    User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
+    return new CategoryModel(category, user);
   }
 
   @RequestMapping(method = RequestMethod.GET)
-  Collection<CategoryModel> getAll(@PathVariable int courseId) {
+  Collection<CategoryModel> getAll(@PathVariable int courseId, HttpSession session) {
     Course course = this.assertCourse(courseId);
-    return course.getCategories().stream().map(CategoryModel::new).collect(Collectors.toList());
+    User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
+    return course.getCategories().stream().map(category -> new CategoryModel(category, user)).collect(Collectors.toList());
   }
 
   @RequestMapping(method = RequestMethod.POST)
   ResponseEntity<CategoryModel> post(
-      @PathVariable int courseId, @RequestBody CategoryInputModel categoryInput) {
+      @PathVariable int courseId, @RequestBody CategoryInputModel categoryInput, HttpSession session) {
     Course course = this.assertCourse(courseId);
+    User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
     Category newCategory =
         categoryRepository.save(
             new Category(course, categoryInput.getName(), categoryInput.getDescription()));
-    return new ResponseEntity<>(new CategoryModel(newCategory), HttpStatus.CREATED);
+    return new ResponseEntity<>(new CategoryModel(newCategory, user), HttpStatus.CREATED);
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{categoryId}")

--- a/src/main/java/com/onkibot/backend/api/CategoryController.java
+++ b/src/main/java/com/onkibot/backend/api/CategoryController.java
@@ -39,12 +39,18 @@ public class CategoryController {
   Collection<CategoryModel> getAll(@PathVariable int courseId, HttpSession session) {
     Course course = this.assertCourse(courseId);
     User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
-    return course.getCategories().stream().map(category -> new CategoryModel(category, user)).collect(Collectors.toList());
+    return course
+        .getCategories()
+        .stream()
+        .map(category -> new CategoryModel(category, user))
+        .collect(Collectors.toList());
   }
 
   @RequestMapping(method = RequestMethod.POST)
   ResponseEntity<CategoryModel> post(
-      @PathVariable int courseId, @RequestBody CategoryInputModel categoryInput, HttpSession session) {
+      @PathVariable int courseId,
+      @RequestBody CategoryInputModel categoryInput,
+      HttpSession session) {
     Course course = this.assertCourse(courseId);
     User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
     Category newCategory =

--- a/src/main/java/com/onkibot/backend/api/CourseController.java
+++ b/src/main/java/com/onkibot/backend/api/CourseController.java
@@ -23,15 +23,17 @@ public class CourseController {
   @Autowired private UserRepository userRepository;
 
   @RequestMapping(method = RequestMethod.GET, value = "/{courseId}")
-  public CourseModel get(@PathVariable int courseId) {
+  public CourseModel get(@PathVariable int courseId, HttpSession session) {
     Course course = assertCourse(courseId);
-    return new CourseModel(course);
+    User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
+    return new CourseModel(course, user);
   }
 
   @RequestMapping(method = RequestMethod.GET)
-  public List<CourseModel> getAll() {
+  public List<CourseModel> getAll(HttpSession session) {
     ArrayList<CourseModel> models = new ArrayList<>();
-    courseRepository.findAll().forEach(course -> models.add(new CourseModel(course)));
+    User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
+    courseRepository.findAll().forEach(course -> models.add(new CourseModel(course, user)));
     return models;
   }
 
@@ -44,7 +46,7 @@ public class CourseController {
     user.getAttending().add(course);
     course.getAttendees().add(user);
     userRepository.save(user);
-    return new ResponseEntity<>(new CourseModel(course), HttpStatus.CREATED);
+    return new ResponseEntity<>(new CourseModel(course, user), HttpStatus.CREATED);
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{courseId}")

--- a/src/main/java/com/onkibot/backend/api/ExternalResourceController.java
+++ b/src/main/java/com/onkibot/backend/api/ExternalResourceController.java
@@ -2,7 +2,6 @@ package com.onkibot.backend.api;
 
 import com.onkibot.backend.OnkibotBackendApplication;
 import com.onkibot.backend.database.entities.*;
-import com.onkibot.backend.database.ids.ExternalResourceApprovalId;
 import com.onkibot.backend.database.repositories.*;
 import com.onkibot.backend.exceptions.*;
 import com.onkibot.backend.models.*;

--- a/src/main/java/com/onkibot/backend/api/ResourceController.java
+++ b/src/main/java/com/onkibot/backend/api/ResourceController.java
@@ -48,12 +48,12 @@ public class ResourceController {
   @RequestMapping(method = RequestMethod.GET)
   Collection<ResourceModel> getAll(
       @PathVariable int courseId, @PathVariable int categoryId, HttpSession session) {
-    User sessionUser = OnkibotBackendApplication.assertSessionUser(userRepository, session);
+    User user = OnkibotBackendApplication.assertSessionUser(userRepository, session);
     Category category = this.assertCourseCategory(courseId, categoryId);
     Set<Resource> resources = category.getResources();
     return resources
         .stream()
-        .map(resource -> new ResourceModel(resource, sessionUser))
+        .map(resource -> new ResourceModel(resource, user))
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
@@ -87,7 +87,7 @@ public class ResourceController {
     savedExternalResources.forEach(
         newExternalResource -> savedResource.getExternalResources().add(newExternalResource));
 
-    return new ResponseEntity<>(new ResourceModel(savedResource), HttpStatus.CREATED);
+    return new ResponseEntity<>(new ResourceModel(savedResource, user), HttpStatus.CREATED);
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/{resourceId}")

--- a/src/main/java/com/onkibot/backend/database/entities/ExternalResource.java
+++ b/src/main/java/com/onkibot/backend/database/entities/ExternalResource.java
@@ -27,7 +27,7 @@ public class ExternalResource implements Serializable {
   @JoinColumn(name = "publisher_user_id")
   private User publisherUser;
 
-  @OneToMany(mappedBy = "externalResourceApprovalId.externalResource", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "externalResourceApprovalId.externalResource", cascade = CascadeType.REMOVE)
   @OrderBy("external_resource_id")
   private Set<ExternalResourceApproval> userApprovals;
 

--- a/src/main/java/com/onkibot/backend/database/entities/ExternalResource.java
+++ b/src/main/java/com/onkibot/backend/database/entities/ExternalResource.java
@@ -1,6 +1,7 @@
 package com.onkibot.backend.database.entities;
 
 import java.io.Serializable;
+import java.util.Set;
 import javax.persistence.*;
 
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"resource_id", "url"}))
@@ -25,6 +26,10 @@ public class ExternalResource implements Serializable {
   @ManyToOne
   @JoinColumn(name = "publisher_user_id")
   private User publisherUser;
+
+  @OneToMany(mappedBy = "externalResourceApprovalId.externalResource", fetch = FetchType.LAZY)
+  @OrderBy("external_resource_id")
+  private Set<ExternalResourceApproval> userApprovals;
 
   protected ExternalResource() {}
 
@@ -59,5 +64,13 @@ public class ExternalResource implements Serializable {
 
   public User getPublisherUser() {
     return publisherUser;
+  }
+
+  public Set<ExternalResourceApproval> getUserApprovals() {
+    return userApprovals;
+  }
+
+  public boolean hasUserApproved(User user) {
+    return getUserApprovals() != null && getUserApprovals().stream().anyMatch(approval -> approval.getApprovalUser().getUserId().equals(user.getUserId()));
   }
 }

--- a/src/main/java/com/onkibot/backend/database/entities/ExternalResource.java
+++ b/src/main/java/com/onkibot/backend/database/entities/ExternalResource.java
@@ -71,6 +71,9 @@ public class ExternalResource implements Serializable {
   }
 
   public boolean hasUserApproved(User user) {
-    return getUserApprovals() != null && getUserApprovals().stream().anyMatch(approval -> approval.getApprovalUser().getUserId().equals(user.getUserId()));
+    return getUserApprovals() != null
+        && getUserApprovals()
+            .stream()
+            .anyMatch(approval -> approval.getApprovalUser().getUserId().equals(user.getUserId()));
   }
 }

--- a/src/main/java/com/onkibot/backend/database/entities/Resource.java
+++ b/src/main/java/com/onkibot/backend/database/entities/Resource.java
@@ -70,6 +70,9 @@ public class Resource {
   }
 
   public Optional<ResourceFeedback> getFeedbackForUser(User user) {
-    return getFeedback().stream().filter(feedback -> feedback.getFeedbackUser().getUserId().equals(user.getUserId())).findFirst();
+    return getFeedback()
+        .stream()
+        .filter(feedback -> feedback.getFeedbackUser().getUserId().equals(user.getUserId()))
+        .findFirst();
   }
 }

--- a/src/main/java/com/onkibot/backend/database/entities/Resource.java
+++ b/src/main/java/com/onkibot/backend/database/entities/Resource.java
@@ -68,4 +68,8 @@ public class Resource {
   public Set<ResourceFeedback> getFeedback() {
     return feedback;
   }
+
+  public Optional<ResourceFeedback> getFeedbackForUser(User user) {
+    return getFeedback().stream().filter(feedback -> feedback.getFeedbackUser().getUserId().equals(user.getUserId())).findFirst();
+  }
 }

--- a/src/main/java/com/onkibot/backend/models/CategoryModel.java
+++ b/src/main/java/com/onkibot/backend/models/CategoryModel.java
@@ -20,7 +20,11 @@ public class CategoryModel {
     this.name = category.getName();
     this.description = category.getDescription();
     this.resources =
-        category.getResources().stream().map(resource -> new ResourceModel(resource, forUser)).collect(Collectors.toList());
+        category
+            .getResources()
+            .stream()
+            .map(resource -> new ResourceModel(resource, forUser))
+            .collect(Collectors.toList());
   }
 
   public int getCategoryId() {

--- a/src/main/java/com/onkibot/backend/models/CategoryModel.java
+++ b/src/main/java/com/onkibot/backend/models/CategoryModel.java
@@ -1,6 +1,7 @@
 package com.onkibot.backend.models;
 
 import com.onkibot.backend.database.entities.Category;
+import com.onkibot.backend.database.entities.User;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,13 +14,13 @@ public class CategoryModel {
 
   protected CategoryModel() {}
 
-  public CategoryModel(Category category) {
+  public CategoryModel(Category category, User forUser) {
     this.categoryId = category.getCategoryId();
     this.courseId = category.getCourse().getCourseId();
     this.name = category.getName();
     this.description = category.getDescription();
     this.resources =
-        category.getResources().stream().map(ResourceModel::new).collect(Collectors.toList());
+        category.getResources().stream().map(resource -> new ResourceModel(resource, forUser)).collect(Collectors.toList());
   }
 
   public int getCategoryId() {

--- a/src/main/java/com/onkibot/backend/models/CourseModel.java
+++ b/src/main/java/com/onkibot/backend/models/CourseModel.java
@@ -19,7 +19,11 @@ public class CourseModel {
     this.name = course.getName();
     this.description = course.getDescription();
     this.categories =
-        course.getCategories().stream().map(category -> new CategoryModel(category, forUser)).collect(Collectors.toList());
+        course
+            .getCategories()
+            .stream()
+            .map(category -> new CategoryModel(category, forUser))
+            .collect(Collectors.toList());
     this.attendees =
         course.getAttendees().stream().map(UserModel::new).collect(Collectors.toList());
   }

--- a/src/main/java/com/onkibot/backend/models/CourseModel.java
+++ b/src/main/java/com/onkibot/backend/models/CourseModel.java
@@ -1,6 +1,7 @@
 package com.onkibot.backend.models;
 
 import com.onkibot.backend.database.entities.Course;
+import com.onkibot.backend.database.entities.User;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,12 +14,12 @@ public class CourseModel {
 
   protected CourseModel() {}
 
-  public CourseModel(Course course) {
+  public CourseModel(Course course, User forUser) {
     this.courseId = course.getCourseId();
     this.name = course.getName();
     this.description = course.getDescription();
     this.categories =
-        course.getCategories().stream().map(CategoryModel::new).collect(Collectors.toList());
+        course.getCategories().stream().map(category -> new CategoryModel(category, forUser)).collect(Collectors.toList());
     this.attendees =
         course.getAttendees().stream().map(UserModel::new).collect(Collectors.toList());
   }

--- a/src/main/java/com/onkibot/backend/models/ExternalResourceModel.java
+++ b/src/main/java/com/onkibot/backend/models/ExternalResourceModel.java
@@ -1,6 +1,7 @@
 package com.onkibot.backend.models;
 
 import com.onkibot.backend.database.entities.ExternalResource;
+import com.onkibot.backend.database.entities.User;
 
 public class ExternalResourceModel {
   private int externalResourceId;
@@ -9,18 +10,18 @@ public class ExternalResourceModel {
   private String comment;
   private String url;
   private UserModel publisherUser;
-  private boolean hasApproved;
+  private boolean myApproval;
 
   protected ExternalResourceModel() {}
 
-  public ExternalResourceModel(ExternalResource externalResource, boolean hasApproved) {
+  public ExternalResourceModel(ExternalResource externalResource, User forUser) {
     this.externalResourceId = externalResource.getExternalResourceId();
     this.resourceId = externalResource.getResource().getResourceId();
     this.title = externalResource.getTitle();
     this.comment = externalResource.getComment();
     this.url = externalResource.getUrl();
     this.publisherUser = new UserModel(externalResource.getPublisherUser());
-    this.hasApproved = hasApproved;
+    this.myApproval = externalResource.hasUserApproved(forUser);
   }
 
   public int getExternalResourceId() {
@@ -47,7 +48,7 @@ public class ExternalResourceModel {
     return publisherUser;
   }
 
-  public boolean getHasApproved() {
-    return hasApproved;
+  public boolean getMyApproval() {
+    return myApproval;
   }
 }

--- a/src/main/java/com/onkibot/backend/models/ResourceModel.java
+++ b/src/main/java/com/onkibot/backend/models/ResourceModel.java
@@ -12,24 +12,11 @@ public class ResourceModel {
   private String body;
   private UserModel publisherUser;
   private List<ExternalResourceModel> externalResources;
+  private ResourceFeedbackModel myFeedback;
 
   protected ResourceModel() {}
 
-  public ResourceModel(Resource resource) {
-    this.resourceId = resource.getResourceId();
-    this.categoryId = resource.getCategory().getCategoryId();
-    this.name = resource.getName();
-    this.body = resource.getBody();
-    this.publisherUser = new UserModel(resource.getPublisherUser());
-    this.externalResources =
-        resource
-            .getExternalResources()
-            .stream()
-            .map(externalResource -> new ExternalResourceModel(externalResource, false))
-            .collect(Collectors.toList());
-  }
-
-  public ResourceModel(Resource resource, User sessionUser) {
+  public ResourceModel(Resource resource, User forUser) {
     this.resourceId = resource.getResourceId();
     this.categoryId = resource.getCategory().getCategoryId();
     this.name = resource.getName();
@@ -43,8 +30,9 @@ public class ResourceModel {
                 externalResource ->
                     new ExternalResourceModel(
                         externalResource,
-                        sessionUser.hasApprovedExternalResource(externalResource)))
+                        forUser))
             .collect(Collectors.toList());
+    this.myFeedback = resource.getFeedbackForUser(forUser).map(ResourceFeedbackModel::new).orElse(null);
   }
 
   public int getResourceId() {
@@ -69,5 +57,9 @@ public class ResourceModel {
 
   public List<ExternalResourceModel> getExternalResources() {
     return externalResources;
+  }
+
+  public ResourceFeedbackModel getMyFeedback() {
+    return myFeedback;
   }
 }

--- a/src/main/java/com/onkibot/backend/models/ResourceModel.java
+++ b/src/main/java/com/onkibot/backend/models/ResourceModel.java
@@ -26,13 +26,10 @@ public class ResourceModel {
         resource
             .getExternalResources()
             .stream()
-            .map(
-                externalResource ->
-                    new ExternalResourceModel(
-                        externalResource,
-                        forUser))
+            .map(externalResource -> new ExternalResourceModel(externalResource, forUser))
             .collect(Collectors.toList());
-    this.myFeedback = resource.getFeedbackForUser(forUser).map(ResourceFeedbackModel::new).orElse(null);
+    this.myFeedback =
+        resource.getFeedbackForUser(forUser).map(ResourceFeedbackModel::new).orElse(null);
   }
 
   public int getResourceId() {

--- a/src/main/java/com/onkibot/backend/models/UserDetailModel.java
+++ b/src/main/java/com/onkibot/backend/models/UserDetailModel.java
@@ -16,20 +16,20 @@ public class UserDetailModel extends UserModel {
     super(user);
     this.email = user.getEmail();
     this.attending =
-            user.getAttending()
-                    .stream()
-                    .map(course -> new CourseModel(course, user))
-                    .collect(Collectors.toList());
+        user.getAttending()
+            .stream()
+            .map(course -> new CourseModel(course, user))
+            .collect(Collectors.toList());
     this.resources =
-            user.getResources()
-                    .stream()
-                    .map(resource -> new ResourceModel(resource, user))
-                    .collect(Collectors.toList());
+        user.getResources()
+            .stream()
+            .map(resource -> new ResourceModel(resource, user))
+            .collect(Collectors.toList());
     this.externalResources =
-            user.getExternalResources()
-                    .stream()
-                    .map(externalResource -> new ExternalResourceModel(externalResource, user))
-                    .collect(Collectors.toList());
+        user.getExternalResources()
+            .stream()
+            .map(externalResource -> new ExternalResourceModel(externalResource, user))
+            .collect(Collectors.toList());
   }
 
   public String getEmail() {

--- a/src/main/java/com/onkibot/backend/models/UserDetailModel.java
+++ b/src/main/java/com/onkibot/backend/models/UserDetailModel.java
@@ -13,19 +13,26 @@ public class UserDetailModel extends UserModel {
   protected UserDetailModel() {}
 
   public UserDetailModel(User user) {
+    this(user, user);
+  }
+
+  public UserDetailModel(User user, User forUser) {
     super(user);
     this.email = user.getEmail();
     this.attending =
-        user.getAttending().stream().map(CourseModel::new).collect(Collectors.toList());
+        user.getAttending()
+            .stream()
+            .map(course -> new CourseModel(course, forUser))
+            .collect(Collectors.toList());
     this.resources =
-        user.getResources().stream().map(ResourceModel::new).collect(Collectors.toList());
+        user.getResources()
+            .stream()
+            .map(resource -> new ResourceModel(resource, forUser))
+            .collect(Collectors.toList());
     this.externalResources =
         user.getExternalResources()
             .stream()
-            .map(
-                externalResource ->
-                    new ExternalResourceModel(
-                        externalResource, user.hasApprovedExternalResource(externalResource)))
+            .map(externalResource -> new ExternalResourceModel(externalResource, user))
             .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/onkibot/backend/models/UserDetailModel.java
+++ b/src/main/java/com/onkibot/backend/models/UserDetailModel.java
@@ -13,27 +13,23 @@ public class UserDetailModel extends UserModel {
   protected UserDetailModel() {}
 
   public UserDetailModel(User user) {
-    this(user, user);
-  }
-
-  public UserDetailModel(User user, User forUser) {
     super(user);
     this.email = user.getEmail();
     this.attending =
-        user.getAttending()
-            .stream()
-            .map(course -> new CourseModel(course, forUser))
-            .collect(Collectors.toList());
+            user.getAttending()
+                    .stream()
+                    .map(course -> new CourseModel(course, user))
+                    .collect(Collectors.toList());
     this.resources =
-        user.getResources()
-            .stream()
-            .map(resource -> new ResourceModel(resource, forUser))
-            .collect(Collectors.toList());
+            user.getResources()
+                    .stream()
+                    .map(resource -> new ResourceModel(resource, user))
+                    .collect(Collectors.toList());
     this.externalResources =
-        user.getExternalResources()
-            .stream()
-            .map(externalResource -> new ExternalResourceModel(externalResource, user))
-            .collect(Collectors.toList());
+            user.getExternalResources()
+                    .stream()
+                    .map(externalResource -> new ExternalResourceModel(externalResource, user))
+                    .collect(Collectors.toList());
   }
 
   public String getEmail() {

--- a/src/test/java/com/onkibot/backend/api/CategoryControllerTest.java
+++ b/src/test/java/com/onkibot/backend/api/CategoryControllerTest.java
@@ -133,6 +133,8 @@ public class CategoryControllerTest {
   @Test
   @WithMockUser(authorities = {"USER"})
   public void testGetCategoryWithAuthentication() throws Exception {
+    User publisherUser = createRepositoryUser();
+    MockHttpSession mockHttpSession = getAuthenticatedSession(publisherUser);
     Course course = createRepositoryCourse();
     Category category = createRepositoryCategory(course);
 
@@ -146,6 +148,7 @@ public class CategoryControllerTest {
                         + API_PATH
                         + "/"
                         + category.getCategoryId())
+                    .session(mockHttpSession)
                     .accept(MediaType.ALL))
             .andExpect(status().isOk())
             .andReturn();
@@ -171,6 +174,8 @@ public class CategoryControllerTest {
   @Test
   @WithMockUser(authorities = {"USER"})
   public void testGetCategoriesWithAuthentication() throws Exception {
+    User publisherUser = createRepositoryUser();
+    MockHttpSession mockHttpSession = getAuthenticatedSession(publisherUser);
     Course course = createRepositoryCourse();
     Category category1 = createRepositoryCategory(course);
     Category category2 = createRepositoryCategory(course);
@@ -179,6 +184,7 @@ public class CategoryControllerTest {
         this.mockMvc
             .perform(
                 get(API_URL_COURSE + "/" + course.getCourseId() + "/" + API_PATH)
+                    .session(mockHttpSession)
                     .accept(MediaType.ALL))
             .andExpect(status().isOk())
             .andReturn();
@@ -218,6 +224,8 @@ public class CategoryControllerTest {
   public void testCreateCategoryWithAuthentication() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
 
+    User publisherUser = createRepositoryUser();
+    MockHttpSession mockHttpSession = getAuthenticatedSession(publisherUser);
     Course course = createRepositoryCourse();
 
     CategoryInputModel categoryInputModel =
@@ -229,6 +237,7 @@ public class CategoryControllerTest {
                 post(API_URL_COURSE + "/" + course.getCourseId() + "/" + API_PATH)
                     .content(mapper.writeValueAsString(categoryInputModel))
                     .contentType(MediaType.APPLICATION_JSON)
+                    .session(mockHttpSession)
                     .accept(MediaType.ALL))
             .andExpect(status().isCreated())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))


### PR DESCRIPTION
ResourceModel now contains `myFeedback` and ExternalResourceModel now contains `myApproval`. Because of cascading models, the user context is required for almost all outward facing model classes.